### PR TITLE
Potential fix for code scanning alert no. 4: Prototype-polluting function

### DIFF
--- a/src/build/helpers.ts
+++ b/src/build/helpers.ts
@@ -134,6 +134,9 @@ export function merge<T>(
     throw new Error("Either `target` or `src` is null");
   }
   for (const k in src) {
+    if (k === "__proto__" || k === "constructor" || k === "prototype") {
+      continue;
+    }
     if (Object.getOwnPropertyDescriptor(src, k)) {
       if (Object.getOwnPropertyDescriptor(target, k)) {
         const targetProp = target[k];


### PR DESCRIPTION
Potential fix for [https://github.com/Bashamega/TypeScript-DOM-lib-generator/security/code-scanning/4](https://github.com/Bashamega/TypeScript-DOM-lib-generator/security/code-scanning/4)

In general, to fix prototype pollution in deep-merge utilities, you must prevent writes to special keys that can affect the prototype chain (`__proto__`, `prototype`, `constructor`) and/or ensure that recursive merging only happens for own properties of the destination object. Here, the function already checks `Object.getOwnPropertyDescriptor(src, k)` and `Object.getOwnPropertyDescriptor(target, k)` before some operations, but it still allows writing dangerous keys directly to `target`. The safest minimal fix, without changing the existing merging semantics for legitimate keys, is to skip any properties whose key is one of the known dangerous ones.

The single best fix in this snippet is therefore to add an explicit key filter in the `for (const k in src)` loop, right after entering the loop, to `continue` when `k` is `"__proto__"`, `"prototype"`, or `"constructor"`. This ensures that neither the recursive-merge path (`target[k] = merge(...)`) nor the simple assignment path (`target[k] = src[k]`) can ever write those properties. All existing logic for normal keys remains unchanged. No new imports are required; we only add a small conditional block near line 136 in `src/build/helpers.ts`.

Concretely:
- In `src/build/helpers.ts`, within `export function merge<T>(...)`, inside the `for (const k in src) { ... }` loop (starting at line 136), insert a guard like:

```ts
if (k === "__proto__" || k === "constructor" || k === "prototype") {
  continue;
}
```

- Place this guard immediately after the `for` line and before any use of `k` (before the `Object.getOwnPropertyDescriptor(src, k)` check), so all branches are protected.
- No other behavior of `merge` is modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
